### PR TITLE
coalesce reporting query for various apis, for when APIs don't work

### DIFF
--- a/resources/portfolio.sql
+++ b/resources/portfolio.sql
@@ -1,7 +1,8 @@
 with now as (
   select (now() at time zone 'pst')::date now
 ), datasource as (
-  select 'TIINGO'::text as datasource
+  select 'ALPHA-VANTAGE'::text as datasource
+--  select 'TIINGO'::text as datasource
 ), date as (
   select
     (select now from now) today,
@@ -33,12 +34,16 @@ with now as (
 ), portfolio as (
   select
     markets.description,
-    portfolio.*
+    portfolio.ticker,
+    portfolio.quantity,
+    portfolio.cost_per_share
   from
     dw.portfolio_dim portfolio
     join dw.markets_dim markets on markets.ticker = portfolio.ticker
   where
     portfolio.dataset = ( select datasource from datasource )
+  group by
+    1,2,3,4
 ), today as (
   select
     portfolio.description,


### PR DESCRIPTION
coalesce reporting, as APIs may return results at various times but no single api is good enough

ie. tiingo and alpha vantage and morningstar

morningstar works consistently and updates @ 3.17pm, but only on a handful of tickers
tiingo works 50% of the time and updates @ 5.40pm, on all tickers
alpha vantage works 50% of the time and updates @ ~7pm (still need to test), on all tickers

given this, send out a report @ 7pm reflecting the best data to chose per ticker (ie if tiingo and morningstar are down but morningstar is up, choose morningstar. if tiingo and morningstar are up, choose tiingo. do this at the ticker level, not at report level (choose only tiingo for everything) as this means the report will break when an api is down.

goal is to add this functionality to the reporting, and then find better api providers that can update by 3.30pm (close of market)